### PR TITLE
Fix version updater bug

### DIFF
--- a/src/config/db_setup/mod.rs
+++ b/src/config/db_setup/mod.rs
@@ -30,7 +30,7 @@ pub fn version_updater(conn: &mut PgConnection) -> QueryResult<()> {
         if current_version < target_version {
             update_function(conn)?;
         }
-        if target_version < max_version {
+        if target_version > max_version {
             max_version = target_version;
         }
     }


### PR DESCRIPTION
## Summary
- fix logic that tracks highest migration version

## Testing
- `cargo test --no-run` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68402d003158833094d696dac2a8c859