### PR TITLE
Secure example JWT keys and add local setup script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,48 +1,15 @@
+# Copy this file to .env for local development.
+# Do not commit .env or any real private keys/secrets.
 DATABASE_URL=postgres://your_username:your_password@db:5432/your_db_name
 POSTGRES_DB=your_db_name
 POSTGRES_USER=your_username
 POSTGRES_PASSWORD=your_password
-PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDBXXxvSLFb34oK
-YgZuh3+9vcI/YzKu5vWJxNAT6QA/21jzNSLHj6jUPOiWfSfB3iH5eAR2c0A2itG3
-51KVcvNEq0aqTmFMvTMb9/LMUwOmLsmD8fuJUAgvRZfDB6uPo8BMIKN7ietToxcm
-M9ARfhoks6EAADc5QM45ztkDfp6HWl/WPvkfF4DJnnJJWuCs9jUhcw5GxrmUfvCT
-jpwQPgsuSSteUw0RHyofrv9rkccYdwzfRKprGyogjmcH9M7/RbRgCxS8ddpGWw64
-ONzuS6UZCNHSC8P/DKockdHS2VV5XqmFRgX+ruIshQpjWtlI+SNNWnMO/2oNlqVF
-lUF8M4YHAgMBAAECggEAR72inDsxKm/+bCnATyPQnhoYRqJMPJ4N/UZbGPf6kraU
-Au/07mt7bPsIJEVdCc2bd04zAaty6ImKk5ushSw324NcXXVlHi6YFslgeLRYB0EW
-nPCbrW9XCgrc6owe99T+VIBLh1s9RzOcNB1HFiZeFr3afwCVfJVxrfrzgxtoP7j/
-1ZQko5DvwuwPyqxKInsxw2k67VsjN0mst19ga5SkO/Fnf7UoG1Fu/1Wxi4UodB4v
-fHmIsfrlRk1E63aMTAUAli0u78XeA7gqsHSCNeinglE0Lk9CqmKfSQ/8WdukDZ28
-UVPMNnGNBi8FFx6khkFTzg0OI8gO7rVzNQPn5Db0YQKBgQDoGQSdqCCmAUpLFq6L
-vbG0q8QWVwV31b9iTMKYc0bqehz4gw9sPDE4g62t7kezYC/CLUNT2epxzXaM5NJG
-MIDXiZSxLuth23rKLdJJJRZRtRCwIQ9BEQzEdNx7/Prp1GAJ/s7V3hjS2Wr+5Fw5
-FOr5UvXC7RQRfvjWnlcFZk3nsQKBgQDVR1SMwxml1hdgDfWiEZZDbiUoXINwJnHF
-dLCJdlCMTyqNM0EadliwUG9aTKwGFSIJIKYYt6pqgapag4oNjinALWYGxA83OA2c
-Dq2t/KmTqswgulS9iPG3/GLUa8X+zxRFOMkFKyYS8v9PafDDdtwvRRrZivBW5WNd
-UeCC21FvNwKBgDGWdsgATclp6SeV1wEALGF/eUuUmBR8VIF6CPFtX69lG5900Oy9
-B38dkxPgHu2SFWIVLZdSraZW0YdUtCBO6JgkSuJ4Nc4YiGl91LnP9K7MUp5u0cWD
-EQlANoM/D5S5zTMVf7dt1jvmO9ftjk6by4AtW1ikMm9yg1PHTKxYqThhAoGBANSe
-NaXWYd03Xzo88GFPUxOJ3LUt9UJ6sPT97Xg8YPRff7YgIIj27ldm+Ht28A9oRfP/
-flYp01Q2S9PMSnZVAT46g/m+vsR3tumaoH5Q4eT6YmFGIHCK8x5OF2BYyJvLaRPR
-FmV2rJA7e1Z58LGL7tmY9Llmj06xg6tmkoEhjz9lAoGAJkJaoXqWQ0GQFZCVQtP/
-UcnlYg2CmZ6gFW02O2DXekxgt+X4rA15mpMrGZl5Jc3Og2GXx0nV4NZbnTLgyap/
-HU370pLsnAWsB1K1Y8zJjvXM0JKCK75rwrz8d5940FW6gWGihBOwYoQpBRRBPj/T
-h7OGi0NvN+uxmHO83GX+XBk=
------END PRIVATE KEY-----
-"
 
-PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwV18b0ixW9+KCmIGbod/
-vb3CP2Myrub1icTQE+kAP9tY8zUix4+o1Dzoln0nwd4h+XgEdnNANorRt+dSlXLz
-RKtGqk5hTL0zG/fyzFMDpi7Jg/H7iVAIL0WXwwerj6PATCCje4nrU6MXJjPQEX4a
-JLOhAAA3OUDOOc7ZA36eh1pf1j75HxeAyZ5ySVrgrPY1IXMORsa5lH7wk46cED4L
-LkkrXlMNER8qH67/a5HHGHcM30SqaxsqII5nB/TO/0W0YAsUvHXaRlsOuDjc7kul
-GQjR0gvD/wyqHJHR0tlVeV6phUYF/q7iLIUKY1rZSPkjTVpzDv9qDZalRZVBfDOG
-BwIDAQAB
------END PUBLIC KEY-----
-"
-
+# JWT signing keys.
+# Keep placeholders in this committed example. Run `make setup` to create a local
+# .env with a freshly generated RSA key pair, or follow the README commands.
+PRIVATE_KEY="replace-with-generated-rsa-private-key"
+PUBLIC_KEY="replace-with-generated-rsa-public-key"
 
 # To use a specific mnemonic:
 ETH_MNEMONIC="smooth satoshi cereal entire drive reveal venture among skirt planet grain crouch"
@@ -78,4 +45,3 @@ S3_EXTERNAL_PORT=9000
 
 S3_INTERNAL_SCHEME=http
 S3_EXTERNAL_SCHEME=http
-

--- a/Makefile
+++ b/Makefile
@@ -140,14 +140,9 @@ shell: ## Enter container shell (use: make shell SERVICE=app)
 	docker-compose exec $(SERVICE) /bin/sh
 
 # Setup
-setup: ## Initial setup - create .env file
-	@if [ ! -f .env ]; then \
-		cp .env.example .env; \
-		echo "$(GREEN).env file created from .env.example$(NC)"; \
-		echo "$(YELLOW)Edit .env and configure necessary values!$(NC)"; \
-	else \
-		echo "$(YELLOW).env file already exists$(NC)"; \
-	fi
+setup: ## Initial setup - create .env file and local JWT keys
+	@./scripts/setup-env.sh
+	@echo "$(YELLOW)Edit .env and configure environment-specific values!$(NC)"
 
 # Health check
 health: ## Check services health status

--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ Create a local `.env` file from the example:
 make setup
 ```
 
-Then edit `.env` for your environment.
+`make setup` copies `.env.example` to `.env` and, when OpenSSL and Python 3 are available, replaces the committed JWT placeholders with a freshly generated local RSA key pair. Then edit `.env` for your environment-specific database, object-storage, Ethereum, and bootstrap-admin values.
 
 ### RSA keys for JWT signing
 
-Generate a private/public RSA key pair:
+`.env.example` intentionally contains only non-secret JWT key placeholders. Use `make setup` for local development, or generate a private/public RSA key pair manually:
 
 ```bash
 openssl genpkey -algorithm RSA -out private.key -pkeyopt rsa_keygen_bits:2048
@@ -120,7 +120,7 @@ PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
 -----END PUBLIC KEY-----"
 ```
 
-Do not commit real private keys or production secrets.
+Do not commit `.env`, real private keys, or production secrets.
 
 ### PostgreSQL
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ This checklist is organized around the current RustLearn architecture: Actix Web
 
 ## Priority 0 — Security, correctness, and contributor safety
 
-- [ ] Replace example RSA private/public keys in `.env.example` with non-secret placeholders and document local key generation only.
+- [x] Replace example RSA private/public keys in `.env.example` with non-secret placeholders and document local key generation only.
 - [ ] Audit all API read endpoints for missing authorization checks, especially user, course, organization, role, wallet, transaction, notification, and reporting data.
 - [ ] Add password strength validation to registration.
 - [ ] Add email confirmation or account-verification flow after registration.
@@ -25,7 +25,7 @@ This checklist is organized around the current RustLearn architecture: Actix Web
 
 ## Priority 2 — Developer experience and setup
 
-- [ ] Add a setup script to generate RSA keys and create a safe local `.env` from placeholders.
+- [x] Add a setup script to generate RSA keys and create a safe local `.env` from placeholders.
 - [ ] Improve `.env.example` comments for PostgreSQL, S3/RustFS, Ethereum provider, admin bootstrap, and worker variables.
 - [ ] Add a quickstart path for running only the API dependencies with Docker Compose.
 - [ ] Add troubleshooting notes for Diesel migration failures, S3 connectivity, Ethereum RPC startup, and worker memory limits.

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${1:-.env}"
+EXAMPLE_FILE="${2:-.env.example}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  echo "$ENV_FILE already exists; leaving it unchanged."
+  exit 0
+fi
+
+if [[ ! -f "$EXAMPLE_FILE" ]]; then
+  echo "Missing $EXAMPLE_FILE" >&2
+  exit 1
+fi
+
+cp "$EXAMPLE_FILE" "$ENV_FILE"
+echo "Created $ENV_FILE from $EXAMPLE_FILE."
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "OpenSSL is not installed; keep the JWT placeholders until you generate keys manually." >&2
+  exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is not installed; keep the JWT placeholders until you add generated keys manually." >&2
+  exit 0
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PRIVATE_KEY_FILE="$TMP_DIR/private.key"
+PUBLIC_KEY_FILE="$TMP_DIR/public.key"
+
+openssl genpkey -algorithm RSA -out "$PRIVATE_KEY_FILE" -pkeyopt rsa_keygen_bits:2048 >/dev/null 2>&1
+openssl rsa -pubout -in "$PRIVATE_KEY_FILE" -out "$PUBLIC_KEY_FILE" >/dev/null 2>&1
+
+python3 - "$ENV_FILE" "$PRIVATE_KEY_FILE" "$PUBLIC_KEY_FILE" <<'PY'
+from pathlib import Path
+import sys
+
+env_path = Path(sys.argv[1])
+private_key = Path(sys.argv[2]).read_text().strip()
+public_key = Path(sys.argv[3]).read_text().strip()
+
+lines = env_path.read_text().splitlines()
+updated = []
+for line in lines:
+    if line.startswith("PRIVATE_KEY="):
+        updated.append(f'PRIVATE_KEY="{private_key}"')
+    elif line.startswith("PUBLIC_KEY="):
+        updated.append(f'PUBLIC_KEY="{public_key}"')
+    else:
+        updated.append(line)
+
+env_path.write_text("\n".join(updated) + "\n")
+PY
+
+echo "Generated a local RSA key pair for JWT signing in $ENV_FILE."
+echo "Do not commit $ENV_FILE."


### PR DESCRIPTION
### Motivation
- Remove committed RSA private/public key material from `.env.example` to avoid accidental secret commits and reduce contributor risk. 
- Provide a reproducible, safe local developer setup path that generates ephemeral JWT RSA keys for `.env` rather than shipping real keys in the repo. 
- Improve onboarding by wiring key generation into the existing `make setup` flow and documenting the behavior in the `README`. 

### Description
- Replace the long example RSA key blocks in `.env.example` with non-secret placeholders and explanatory comments instructing developers to use `make setup` or manual key generation. 
- Add `scripts/setup-env.sh`, which copies `.env.example` to `.env`, detects `openssl`/`python3`, generates an RSA key pair, and injects the keys into the local `.env` file. 
- Update the `Makefile` `setup` target to run `./scripts/setup-env.sh` so `make setup` performs local key generation when tools are available. 
- Update `README.md` setup instructions and mark the corresponding TODO items in `TODO.md` as completed. 

### Testing
- Ran the setup script in a temporary location with `./scripts/setup-env.sh "$TMP_DIR/.env" .env.example` and confirmed it created `.env` and injected generated RSA keys (smoke test passed). 
- Performed a syntax check with `bash -n scripts/setup-env.sh` which passed. 
- Ran `git diff --check` to ensure no whitespace or patch issues, which passed. 
- Ran `cargo fmt --all --check` and observed it failed due to existing repository Rust formatting drift unrelated to these changes; no Rust source behavior was modified in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d269764f88330b1a6ef575d21159b)