### PR TITLE
Generate local JWT keys on setup and enforce password strength on registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,48 +1,15 @@
+# Copy this file to .env for local development.
+# Do not commit .env or any real private keys/secrets.
 DATABASE_URL=postgres://your_username:your_password@db:5432/your_db_name
 POSTGRES_DB=your_db_name
 POSTGRES_USER=your_username
 POSTGRES_PASSWORD=your_password
-PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDBXXxvSLFb34oK
-YgZuh3+9vcI/YzKu5vWJxNAT6QA/21jzNSLHj6jUPOiWfSfB3iH5eAR2c0A2itG3
-51KVcvNEq0aqTmFMvTMb9/LMUwOmLsmD8fuJUAgvRZfDB6uPo8BMIKN7ietToxcm
-M9ARfhoks6EAADc5QM45ztkDfp6HWl/WPvkfF4DJnnJJWuCs9jUhcw5GxrmUfvCT
-jpwQPgsuSSteUw0RHyofrv9rkccYdwzfRKprGyogjmcH9M7/RbRgCxS8ddpGWw64
-ONzuS6UZCNHSC8P/DKockdHS2VV5XqmFRgX+ruIshQpjWtlI+SNNWnMO/2oNlqVF
-lUF8M4YHAgMBAAECggEAR72inDsxKm/+bCnATyPQnhoYRqJMPJ4N/UZbGPf6kraU
-Au/07mt7bPsIJEVdCc2bd04zAaty6ImKk5ushSw324NcXXVlHi6YFslgeLRYB0EW
-nPCbrW9XCgrc6owe99T+VIBLh1s9RzOcNB1HFiZeFr3afwCVfJVxrfrzgxtoP7j/
-1ZQko5DvwuwPyqxKInsxw2k67VsjN0mst19ga5SkO/Fnf7UoG1Fu/1Wxi4UodB4v
-fHmIsfrlRk1E63aMTAUAli0u78XeA7gqsHSCNeinglE0Lk9CqmKfSQ/8WdukDZ28
-UVPMNnGNBi8FFx6khkFTzg0OI8gO7rVzNQPn5Db0YQKBgQDoGQSdqCCmAUpLFq6L
-vbG0q8QWVwV31b9iTMKYc0bqehz4gw9sPDE4g62t7kezYC/CLUNT2epxzXaM5NJG
-MIDXiZSxLuth23rKLdJJJRZRtRCwIQ9BEQzEdNx7/Prp1GAJ/s7V3hjS2Wr+5Fw5
-FOr5UvXC7RQRfvjWnlcFZk3nsQKBgQDVR1SMwxml1hdgDfWiEZZDbiUoXINwJnHF
-dLCJdlCMTyqNM0EadliwUG9aTKwGFSIJIKYYt6pqgapag4oNjinALWYGxA83OA2c
-Dq2t/KmTqswgulS9iPG3/GLUa8X+zxRFOMkFKyYS8v9PafDDdtwvRRrZivBW5WNd
-UeCC21FvNwKBgDGWdsgATclp6SeV1wEALGF/eUuUmBR8VIF6CPFtX69lG5900Oy9
-B38dkxPgHu2SFWIVLZdSraZW0YdUtCBO6JgkSuJ4Nc4YiGl91LnP9K7MUp5u0cWD
-EQlANoM/D5S5zTMVf7dt1jvmO9ftjk6by4AtW1ikMm9yg1PHTKxYqThhAoGBANSe
-NaXWYd03Xzo88GFPUxOJ3LUt9UJ6sPT97Xg8YPRff7YgIIj27ldm+Ht28A9oRfP/
-flYp01Q2S9PMSnZVAT46g/m+vsR3tumaoH5Q4eT6YmFGIHCK8x5OF2BYyJvLaRPR
-FmV2rJA7e1Z58LGL7tmY9Llmj06xg6tmkoEhjz9lAoGAJkJaoXqWQ0GQFZCVQtP/
-UcnlYg2CmZ6gFW02O2DXekxgt+X4rA15mpMrGZl5Jc3Og2GXx0nV4NZbnTLgyap/
-HU370pLsnAWsB1K1Y8zJjvXM0JKCK75rwrz8d5940FW6gWGihBOwYoQpBRRBPj/T
-h7OGi0NvN+uxmHO83GX+XBk=
------END PRIVATE KEY-----
-"
 
-PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwV18b0ixW9+KCmIGbod/
-vb3CP2Myrub1icTQE+kAP9tY8zUix4+o1Dzoln0nwd4h+XgEdnNANorRt+dSlXLz
-RKtGqk5hTL0zG/fyzFMDpi7Jg/H7iVAIL0WXwwerj6PATCCje4nrU6MXJjPQEX4a
-JLOhAAA3OUDOOc7ZA36eh1pf1j75HxeAyZ5ySVrgrPY1IXMORsa5lH7wk46cED4L
-LkkrXlMNER8qH67/a5HHGHcM30SqaxsqII5nB/TO/0W0YAsUvHXaRlsOuDjc7kul
-GQjR0gvD/wyqHJHR0tlVeV6phUYF/q7iLIUKY1rZSPkjTVpzDv9qDZalRZVBfDOG
-BwIDAQAB
------END PUBLIC KEY-----
-"
-
+# JWT signing keys.
+# Keep placeholders in this committed example. Run `make setup` to create a local
+# .env with a freshly generated RSA key pair, or follow the README commands.
+PRIVATE_KEY="replace-with-generated-rsa-private-key"
+PUBLIC_KEY="replace-with-generated-rsa-public-key"
 
 # To use a specific mnemonic:
 ETH_MNEMONIC="smooth satoshi cereal entire drive reveal venture among skirt planet grain crouch"
@@ -78,4 +45,3 @@ S3_EXTERNAL_PORT=9000
 
 S3_INTERNAL_SCHEME=http
 S3_EXTERNAL_SCHEME=http
-

--- a/Makefile
+++ b/Makefile
@@ -140,14 +140,9 @@ shell: ## Enter container shell (use: make shell SERVICE=app)
 	docker-compose exec $(SERVICE) /bin/sh
 
 # Setup
-setup: ## Initial setup - create .env file
-	@if [ ! -f .env ]; then \
-		cp .env.example .env; \
-		echo "$(GREEN).env file created from .env.example$(NC)"; \
-		echo "$(YELLOW)Edit .env and configure necessary values!$(NC)"; \
-	else \
-		echo "$(YELLOW).env file already exists$(NC)"; \
-	fi
+setup: ## Initial setup - create .env file and local JWT keys
+	@./scripts/setup-env.sh
+	@echo "$(YELLOW)Edit .env and configure environment-specific values!$(NC)"
 
 # Health check
 health: ## Check services health status

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ See [`VISION.md`](VISION.md) for the product and architecture direction, and [`T
 - Rust 2021 with Actix Web.
 - JWT-protected `/api` scope.
 - Route modules for authentication, users, courses, organizations, and roles.
+- Registration rejects weak passwords: passwords must be at least 12 characters and include lowercase, uppercase, numeric, and symbol characters.
 - Diesel and Diesel Async with PostgreSQL.
 - Repository and service layers for persistence/business logic.
 
@@ -97,11 +98,11 @@ Create a local `.env` file from the example:
 make setup
 ```
 
-Then edit `.env` for your environment.
+`make setup` copies `.env.example` to `.env` and, when OpenSSL and Python 3 are available, replaces the committed JWT placeholders with a freshly generated local RSA key pair. Then edit `.env` for your environment-specific database, object-storage, Ethereum, and bootstrap-admin values.
 
 ### RSA keys for JWT signing
 
-Generate a private/public RSA key pair:
+`.env.example` intentionally contains only non-secret JWT key placeholders. Use `make setup` for local development, or generate a private/public RSA key pair manually:
 
 ```bash
 openssl genpkey -algorithm RSA -out private.key -pkeyopt rsa_keygen_bits:2048
@@ -120,7 +121,7 @@ PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
 -----END PUBLIC KEY-----"
 ```
 
-Do not commit real private keys or production secrets.
+Do not commit `.env`, real private keys, or production secrets.
 
 ### PostgreSQL
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,9 @@ This checklist is organized around the current RustLearn architecture: Actix Web
 
 ## Priority 0 — Security, correctness, and contributor safety
 
-- [ ] Replace example RSA private/public keys in `.env.example` with non-secret placeholders and document local key generation only.
+- [x] Replace example RSA private/public keys in `.env.example` with non-secret placeholders and document local key generation only.
 - [ ] Audit all API read endpoints for missing authorization checks, especially user, course, organization, role, wallet, transaction, notification, and reporting data.
-- [ ] Add password strength validation to registration.
+- [x] Add password strength validation to registration.
 - [ ] Add email confirmation or account-verification flow after registration.
 - [ ] Review JWT expiration, refresh/session strategy, and logout/revocation expectations.
 - [ ] Add a JWKS or `.well-known/jwks.json` endpoint for external JWT verification.
@@ -25,7 +25,7 @@ This checklist is organized around the current RustLearn architecture: Actix Web
 
 ## Priority 2 — Developer experience and setup
 
-- [ ] Add a setup script to generate RSA keys and create a safe local `.env` from placeholders.
+- [x] Add a setup script to generate RSA keys and create a safe local `.env` from placeholders.
 - [ ] Improve `.env.example` comments for PostgreSQL, S3/RustFS, Ethereum provider, admin bootstrap, and worker variables.
 - [ ] Add a quickstart path for running only the API dependencies with Docker Compose.
 - [ ] Add troubleshooting notes for Diesel migration failures, S3 connectivity, Ethereum RPC startup, and worker memory limits.

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${1:-.env}"
+EXAMPLE_FILE="${2:-.env.example}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  echo "$ENV_FILE already exists; leaving it unchanged."
+  exit 0
+fi
+
+if [[ ! -f "$EXAMPLE_FILE" ]]; then
+  echo "Missing $EXAMPLE_FILE" >&2
+  exit 1
+fi
+
+cp "$EXAMPLE_FILE" "$ENV_FILE"
+echo "Created $ENV_FILE from $EXAMPLE_FILE."
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "OpenSSL is not installed; keep the JWT placeholders until you generate keys manually." >&2
+  exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is not installed; keep the JWT placeholders until you add generated keys manually." >&2
+  exit 0
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PRIVATE_KEY_FILE="$TMP_DIR/private.key"
+PUBLIC_KEY_FILE="$TMP_DIR/public.key"
+
+openssl genpkey -algorithm RSA -out "$PRIVATE_KEY_FILE" -pkeyopt rsa_keygen_bits:2048 >/dev/null 2>&1
+openssl rsa -pubout -in "$PRIVATE_KEY_FILE" -out "$PUBLIC_KEY_FILE" >/dev/null 2>&1
+
+python3 - "$ENV_FILE" "$PRIVATE_KEY_FILE" "$PUBLIC_KEY_FILE" <<'PY'
+from pathlib import Path
+import sys
+
+env_path = Path(sys.argv[1])
+private_key = Path(sys.argv[2]).read_text().strip()
+public_key = Path(sys.argv[3]).read_text().strip()
+
+lines = env_path.read_text().splitlines()
+updated = []
+for line in lines:
+    if line.startswith("PRIVATE_KEY="):
+        updated.append(f'PRIVATE_KEY="{private_key}"')
+    elif line.startswith("PUBLIC_KEY="):
+        updated.append(f'PUBLIC_KEY="{public_key}"')
+    else:
+        updated.append(line)
+
+env_path.write_text("\n".join(updated) + "\n")
+PY
+
+echo "Generated a local RSA key pair for JWT signing in $ENV_FILE."
+echo "Do not commit $ENV_FILE."

--- a/src/api/authentication.rs
+++ b/src/api/authentication.rs
@@ -1,14 +1,17 @@
 // src/api/authentication.rs
-use actix_web::{get, post, web, HttpResponse, Responder, HttpRequest};
-use serde::Deserialize;
+use actix_web::{get, post, web, HttpRequest, HttpResponse, Responder};
 use bcrypt::{hash, verify, DEFAULT_COST};
-use crate::models::{authentication::Authentication, user_jwt::UserJWT};
-use crate::models::user::{User, NewUser};
+use chrono::NaiveDate;
+use serde::Deserialize;
+
 use crate::db;
-// use diesel::prelude::*; // Not needed directly if using model methods
-use chrono::{NaiveDate, NaiveDateTime};
+use crate::models::authentication::Authentication;
+use crate::models::role::PlatformRole;
+use crate::models::user::{NewUser, User};
+use crate::models::user_role_platform::UserRolePlatform;
 use crate::utils::jwt_utils::create_jwt;
-use crate::models::{role::PlatformRole, user_role_platform::UserRolePlatform};
+
+const MIN_PASSWORD_LENGTH: usize = 12;
 
 // TODO Add confirmation email on registration
 
@@ -26,13 +29,25 @@ pub struct RegisterRequest {
     pub date_of_birth: Option<NaiveDate>,
 }
 
+fn validate_password_strength(password: &str) -> Result<(), &'static str> {
+    if password.len() < MIN_PASSWORD_LENGTH {
+        return Err("Password must be at least 12 characters long");
+    }
 
+    let has_lowercase = password.chars().any(char::is_lowercase);
+    let has_uppercase = password.chars().any(char::is_uppercase);
+    let has_digit = password.chars().any(|c| c.is_ascii_digit());
+    let has_symbol = password.chars().any(|c| !c.is_alphanumeric());
+
+    if !(has_lowercase && has_uppercase && has_digit && has_symbol) {
+        return Err("Password must include lowercase, uppercase, numeric, and symbol characters");
+    }
+
+    Ok(())
+}
 
 #[post("/login")]
-pub async fn login(
-    pool: web::Data<db::DbPool>,
-    req: web::Json<LoginRequest>,
-) -> impl Responder {
+pub async fn login(pool: web::Data<db::DbPool>, req: web::Json<LoginRequest>) -> impl Responder {
     let mut conn = match pool.get().await {
         Ok(c) => c,
         Err(_) => return HttpResponse::InternalServerError().body("Failed to get DB connection"),
@@ -48,9 +63,7 @@ pub async fn login(
                         Ok(user_jwt) => {
                             HttpResponse::Ok().json(user_jwt) // Return JWT token in response
                         }
-                        Err(_) => {
-                            HttpResponse::InternalServerError().body("Failed to create JWT")
-                        }
+                        Err(_) => HttpResponse::InternalServerError().body("Failed to create JWT"),
                     }
                 } else {
                     HttpResponse::Unauthorized().body("Invalid credentials")
@@ -63,14 +76,15 @@ pub async fn login(
     }
 }
 
-
-
-
 #[post("/register")]
 pub async fn register(
     pool: web::Data<db::DbPool>,
     req: web::Json<RegisterRequest>,
 ) -> impl Responder {
+    if let Err(message) = validate_password_strength(&req.password) {
+        return HttpResponse::BadRequest().body(message);
+    }
+
     let mut conn = match pool.get().await {
         Ok(c) => c,
         Err(_) => return HttpResponse::InternalServerError().body("Failed to get DB connection"),
@@ -93,7 +107,7 @@ pub async fn register(
     let role_id = PlatformRole::find_by_name("STUDENT", &mut conn)
         .await
         .expect("Error finding STUDENT role");
-    
+
     UserRolePlatform::assign(&mut conn, inserted_user.id(), role_id)
         .await
         .expect("Error assigning default role to user");
@@ -113,7 +127,7 @@ pub async fn register(
     HttpResponse::Ok().body("Registration successful")
 }
 
-// hello 
+// hello
 #[get("/hello")]
 pub async fn hello() -> impl Responder {
     HttpResponse::Ok().body("Hello world!")
@@ -124,11 +138,11 @@ pub async fn user_id(req: HttpRequest) -> impl Responder {
     // Try to decode the Authorization header to extract the user ID instead of reading request extensions
     if let Some(auth_header) = req.headers().get("Authorization") {
         if let Ok(auth_str) = auth_header.to_str() {
-            if auth_str.starts_with("Bearer ") {
-                let token = &auth_str["Bearer ".len()..];
+            if let Some(token) = auth_str.strip_prefix("Bearer ") {
                 if let Ok(token_data) = crate::utils::jwt_utils::decode_jwt(token) {
                     let user_jwt = token_data.claims;
-                    return HttpResponse::Ok().body(format!("Hello! Your ID is {}", user_jwt.user_id));
+                    return HttpResponse::Ok()
+                        .body(format!("Hello! Your ID is {}", user_jwt.user_id));
                 }
             }
         }
@@ -140,8 +154,34 @@ pub async fn user_id(req: HttpRequest) -> impl Responder {
 // Define the scope for authentication-related routes
 pub fn auth_scope() -> actix_web::Scope {
     web::scope("/auth")
-    .service(login)
-    .service(register)
-    .service(hello)
-    .service(user_id)
+        .service(login)
+        .service(register)
+        .service(hello)
+        .service(user_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_password_strength;
+
+    #[test]
+    fn accepts_strong_password() {
+        assert!(validate_password_strength("CorrectHorse1!").is_ok());
+    }
+
+    #[test]
+    fn rejects_short_password() {
+        assert_eq!(
+            validate_password_strength("Aa1!").unwrap_err(),
+            "Password must be at least 12 characters long"
+        );
+    }
+
+    #[test]
+    fn rejects_password_missing_required_character_classes() {
+        assert_eq!(
+            validate_password_strength("correcthorse1").unwrap_err(),
+            "Password must include lowercase, uppercase, numeric, and symbol characters"
+        );
+    }
 }


### PR DESCRIPTION
### Motivation

- Prevent committing real RSA keys in `.env.example` and provide a safe local setup path for JWT signing keys.
- Improve account security by enforcing stronger passwords at registration.

### Description

- Replace the large committed RSA key pair in `.env.example` with non-secret placeholders and explanatory comments about `make setup`.
- Add `scripts/setup-env.sh` which copies `.env.example` to `.env`, generates a local RSA key pair with OpenSSL, and injects the keys into the new `.env` file when available.
- Update the `Makefile` `setup` target to run `./scripts/setup-env.sh` and print guidance to edit `.env` for environment-specific values.
- Add password strength validation in `src/api/authentication.rs` (minimum 12 characters and must include lowercase, uppercase, numeric, and symbol characters), enforce it in the `/register` endpoint, and include unit tests for the validator.
- Update `README.md`, `TODO.md` and other docs to document the new setup flow and security-related checklist updates.

### Testing

- Ran the Rust unit tests via `cargo test`, which include the new `validate_password_strength` tests, and they passed.
- No other automated tests were modified or added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d269764f88330b1a6ef575d21159b)