### PR TITLE
[codex] Document environment example variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 # Copy this file to .env for local development.
 # Do not commit .env or any real private keys/secrets.
+
+# PostgreSQL
+# The Docker Compose API and worker containers reach PostgreSQL at host `db`
+# on port 5432. If you run the Rust API directly on the host while only the
+# dependencies run in Compose, use localhost:5433 in DATABASE_URL instead.
 DATABASE_URL=postgres://your_username:your_password@db:5432/your_db_name
+
+# These POSTGRES_* values initialize the Compose postgres container. Keep them
+# aligned with DATABASE_URL.
 POSTGRES_DB=your_db_name
 POSTGRES_USER=your_username
 POSTGRES_PASSWORD=your_password
@@ -11,37 +19,43 @@ POSTGRES_PASSWORD=your_password
 PRIVATE_KEY="replace-with-generated-rsa-private-key"
 PUBLIC_KEY="replace-with-generated-rsa-public-key"
 
-# To use a specific mnemonic:
-ETH_MNEMONIC="smooth satoshi cereal entire drive reveal venture among skirt planet grain crouch"
+# Ethereum / Anvil
+# The Compose Anvil service runs on the Docker DNS host `anvil` and host port
+# 8545. The app container also sets ETH_HOST=anvil explicitly. For a host-run
+# API, prefer ETH_RPC_URL=http://localhost:8545.
+ETH_HOST=anvil
+ETH_PORT=8545
+# ETH_RPC_URL=http://localhost:8545
 
-# Optional Ganache settings (uncomment and set as needed):
-GANACHE_NETWORK_ID=5777 # Default is usually fine (often 1337 for new versions or 5777 for older)
-# GANACHE_ACCOUNT_KEYS_PATH=/path/to/accounts.json # Path *inside the container* if you mount a specific accounts file
-# GANACHE_ACCOUNTS=10 # Number of accounts to generate if not using a specific mnemonic or account_keys_path
-# GANACHE_DEFAULT_BALANCE_ETHER=100 # Default balance for generated accounts
-# GANACHE_GAS_PRICE=20000000000 # Gas price in wei
-# GANACHE_GAS_LIMIT=6721975 # Block gas limit
+# Optional deterministic Anvil mnemonic. Leave unset to use the entrypoint's
+# local development default, or set a non-production mnemonic here.
+# ETH_MNEMONIC="test test test test test test test test test test test junk"
 
-# Admin User for Database Setup (from src/config/db_setup/updates/update_v2.rs)
+# Bootstrap admin user created during database setup.
 ADMIN_NAME=admin
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=supersecretpassword
-ADMIN_DATE_OF_BIRTH=1990-01-01 # YYYY-MM-DD format
+ADMIN_DATE_OF_BIRTH=1990-01-01 # YYYY-MM-DD
 
-# Ethereum provider configuration
-# Prefer ETH_RPC_URL; otherwise ETH_HOST and ETH_PORT are used.
-ETH_HOST=geth
-ETH_PORT=8545
-# ETH_RPC_URL=http://geth:8545
-
-# MinIO Configuration
+# S3-compatible storage / RustFS
+# These development credentials are used by the Compose RustFS service. Replace
+# them with real secrets for any shared or production environment.
 S3_ACCESS_KEY=rustfsadmin
 S3_SECRET_KEY=rustfsadmin
 
+# Internal values are used by app/worker containers through Docker DNS.
 S3_INTERNAL_DOMAIN=rustfs
 S3_INTERNAL_PORT=9000
+S3_INTERNAL_SCHEME=http
+
+# External values are used when generating URLs clients access from the host.
 S3_EXTERNAL_DOMAIN=localhost
 S3_EXTERNAL_PORT=9000
-
-S3_INTERNAL_SCHEME=http
 S3_EXTERNAL_SCHEME=http
+
+# Worker
+# Tune these for video-processing throughput and retry behavior. Keep
+# concurrency conservative on small Docker VMs because ffmpeg is memory-heavy.
+WORKER_CONCURRENCY=1
+WORKER_MAX_ATTEMPTS=5
+WORKER_BASE_BACKOFF_SECONDS=60

--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@ This checklist is organized around the current RustLearn architecture: Actix Web
 ## Priority 2 — Developer experience and setup
 
 - [x] Add a setup script to generate RSA keys and create a safe local `.env` from placeholders.
-- [ ] Improve `.env.example` comments for PostgreSQL, S3/RustFS, Ethereum provider, admin bootstrap, and worker variables.
+- [x] Improve `.env.example` comments for PostgreSQL, S3/RustFS, Ethereum provider, admin bootstrap, and worker variables.
 - [ ] Add a quickstart path for running only the API dependencies with Docker Compose.
 - [ ] Add troubleshooting notes for Diesel migration failures, S3 connectivity, Ethereum RPC startup, and worker memory limits.
 - [ ] Keep `Makefile` targets aligned with README examples.


### PR DESCRIPTION
## Summary

- Expanded `.env.example` guidance for PostgreSQL, Ethereum/Anvil, RustFS/S3, bootstrap admin, and worker variables.
- Removed stale Ganache-oriented example comments from the current Anvil setup notes.
- Checked off the matching Priority 2 TODO item.

## Validation

- `git diff --check`