### PR TITLE
[codex] Add API dependency quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help build run stop test clean docker-build docker-up docker-down setup health \
   k8s-build k8s-apply k8s-delete k8s-status k8s-logs k8s-forward \
-  dev-build dev-run dev-worker migrate migrate-redo \
+  dev-build dev-deps dev-run dev-worker migrate migrate-redo \
   test-integration
 
 # Variables
@@ -95,6 +95,9 @@ k8s-forward: ## Start port-forward (use: make k8s-forward SERVICE=web PORT=3000)
 # Development
 dev-build: ## Build only the Rust application (without container)
 	cargo build --release
+
+dev-deps: ## Start only API dependencies (Postgres, RustFS, Anvil)
+	docker-compose up -d db rustfs anvil
 
 dev-run: ## Run application locally (without container)
 	cargo run --bin rust-learn

--- a/README.md
+++ b/README.md
@@ -204,11 +204,24 @@ The API container runs `scripts/app-entrypoint.sh`, which initializes submodules
 
 ## Running locally without containers
 
-Start dependencies with Docker Compose, then run the Rust API locally if desired:
+Start only the API dependencies with Docker Compose:
+
+```bash
+make dev-deps
+```
+
+This starts PostgreSQL, RustFS, and Anvil without starting the API, web app, or
+worker containers. It is the quickest path when you want to run the Rust API on
+the host with Cargo:
+
+```bash
+cargo run --bin rust-learn
+```
+
+The equivalent raw Docker Compose command is:
 
 ```bash
 docker-compose up -d db rustfs anvil
-cargo run --bin rust-learn
 ```
 
 Run the worker locally:

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@ This checklist is organized around the current RustLearn architecture: Actix Web
 
 - [x] Add a setup script to generate RSA keys and create a safe local `.env` from placeholders.
 - [x] Improve `.env.example` comments for PostgreSQL, S3/RustFS, Ethereum provider, admin bootstrap, and worker variables.
-- [ ] Add a quickstart path for running only the API dependencies with Docker Compose.
+- [x] Add a quickstart path for running only the API dependencies with Docker Compose.
 - [ ] Add troubleshooting notes for Diesel migration failures, S3 connectivity, Ethereum RPC startup, and worker memory limits.
 - [ ] Keep `Makefile` targets aligned with README examples.
 - [ ] Add a short architecture diagram or request-flow diagram to the docs.


### PR DESCRIPTION
## Summary

- Added `make dev-deps` to start only PostgreSQL, RustFS, and Anvil.
- Documented the host-run API quickstart in the README.
- Checked off the matching Priority 2 TODO item.

## Validation

- `make -n dev-deps`
- `git diff --check`