### PR TITLE
[codex] Align Makefile documentation shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help build run stop test clean docker-build docker-up docker-down setup health \
   k8s-build k8s-apply k8s-delete k8s-status k8s-logs k8s-forward \
-  dev-build dev-deps dev-run dev-worker migrate migrate-redo \
-  test-integration
+  dev-build dev-deps dev-run dev-worker worker-build migrate migrate-redo \
+  test-integration fmt web-lint web-build
 
 # Variables
 PROJECT_NAME := rust-learn
@@ -105,12 +105,24 @@ dev-run: ## Run application locally (without container)
 dev-worker: ## Run worker locally (without container)
 	cargo run --bin worker
 
+worker-build: ## Build only the worker Docker image
+	docker-compose build worker
+
 # Tests
 test: ## Run tests
 	cargo test
 
 test-integration: ## Run integration tests
 	cargo test --test blockchain_integration_tests
+
+fmt: ## Check Rust formatting
+	cargo fmt --all --check
+
+web-lint: ## Run frontend lint checks
+	cd web && npm run lint
+
+web-build: ## Build the frontend
+	cd web && npm run build
 
 # DB Migrations
 migrate: ## Run Diesel migrations

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ WORKER_BASE_BACKOFF_SECONDS=60
 Recommended worker build/start flow:
 
 ```bash
-docker compose build worker
+make worker-build
 docker compose up -d db rustfs worker
 ```
 
@@ -303,8 +303,11 @@ npm run build
 Makefile shortcuts:
 
 ```bash
+make fmt
 make test
 make test-integration
+make web-lint
+make web-build
 make health
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -29,7 +29,7 @@ This checklist is organized around the current RustLearn architecture: Actix Web
 - [x] Improve `.env.example` comments for PostgreSQL, S3/RustFS, Ethereum provider, admin bootstrap, and worker variables.
 - [x] Add a quickstart path for running only the API dependencies with Docker Compose.
 - [x] Add troubleshooting notes for Diesel migration failures, S3 connectivity, Ethereum RPC startup, and worker memory limits.
-- [ ] Keep `Makefile` targets aligned with README examples.
+- [x] Keep `Makefile` targets aligned with README examples.
 - [ ] Add a short architecture diagram or request-flow diagram to the docs.
 
 ## Priority 3 — Product features


### PR DESCRIPTION
## Summary

- Added Makefile shortcuts for Rust formatting, frontend lint/build, and worker image builds.
- Updated README shortcut examples to use the new targets.
- Checked off the matching Priority 2 TODO item.

## Validation

- `make -n fmt`
- `make -n web-lint`
- `make -n web-build`
- `make -n worker-build`
- `make help | rg "fmt|web-lint|web-build|worker-build"`
- `git diff --check`