### PR TITLE
[codex] Add architecture flow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ See [`VISION.md`](VISION.md) for the product and architecture direction, and [`T
 └── AGENTS.md               # Contributor/AI-agent guidance
 ```
 
+## Architecture flow
+
+```mermaid
+flowchart LR
+    Browser[Browser] --> Web[Next.js frontend]
+    Web --> API[Actix Web API]
+    API --> Auth[JWT and permission middleware]
+    Auth --> Services[Services and repositories]
+    Services --> Postgres[(PostgreSQL / Diesel)]
+    Services --> RustFS[(RustFS / S3 objects)]
+    Services --> Ethereum[Anvil or Ethereum RPC]
+    API --> Jobs[Upload and video jobs]
+    Jobs --> Worker[Worker binary]
+    Worker --> RustFS
+    Worker --> Postgres
+```
+
 ## Core components
 
 ### Backend API

--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@ This checklist is organized around the current RustLearn architecture: Actix Web
 - [x] Add a quickstart path for running only the API dependencies with Docker Compose.
 - [x] Add troubleshooting notes for Diesel migration failures, S3 connectivity, Ethereum RPC startup, and worker memory limits.
 - [x] Keep `Makefile` targets aligned with README examples.
-- [ ] Add a short architecture diagram or request-flow diagram to the docs.
+- [x] Add a short architecture diagram or request-flow diagram to the docs.
 
 ## Priority 3 — Product features
 


### PR DESCRIPTION
## Summary

- Added a short Mermaid architecture flow diagram to the README.
- Covered the frontend/API path plus database, RustFS/S3, worker, and Ethereum RPC interactions.
- Checked off the matching Priority 2 TODO item.

## Validation

- `git diff --check`