### PR TITLE
[codex] Document test runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,20 @@ make web-build
 make health
 ```
 
-Some tests and runtime paths require local services such as PostgreSQL, RustFS, Anvil, and ffmpeg.
+Test dependency notes:
+
+| Check | External requirements |
+| --- | --- |
+| `make test` / `cargo test` | A valid `.env`; many integration tests open `DATABASE_URL`, so start PostgreSQL first with `make dev-deps` when running the full suite. |
+| `cargo test --test s3` | RustFS/S3-compatible storage reachable through the `S3_*` settings. With Compose, run from the container network or set `S3_INTERNAL_DOMAIN`/`S3_EXTERNAL_DOMAIN` appropriately for the host. |
+| `make test-integration` / `cargo test --test blockchain_integration_tests -- --ignored` | Anvil or another Ethereum JSON-RPC endpoint plus `ETH_MNEMONIC` and provider settings in `.env`. |
+| Worker/media-processing checks | ffmpeg on `PATH`, PostgreSQL, and RustFS/S3. Keep `WORKER_CONCURRENCY=1` on small Docker VMs. |
+
+Docker is the recommended way to provide PostgreSQL, RustFS, and Anvil for local test runs:
+
+```bash
+make dev-deps
+```
 
 ## Database migrations
 

--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ This checklist is organized around the current RustLearn architecture: Actix Web
 - [ ] Add worker tests for retry state transitions, terminal failures, and heartbeat behavior.
 - [ ] Keep blockchain integration tests covering deploy, mint, presigner, and EIP-2612 permit behavior.
 - [ ] Add CI steps for `cargo fmt --all --check`, `cargo test`, and frontend lint/build checks.
-- [ ] Document any tests that require Docker, PostgreSQL, Anvil/Geth, RustFS, or ffmpeg.
+- [x] Document any tests that require Docker, PostgreSQL, Anvil/Geth, RustFS, or ffmpeg.
 
 ## Priority 2 — Developer experience and setup
 


### PR DESCRIPTION
## Summary

- Added README test dependency notes for PostgreSQL, RustFS/S3, Anvil/Ethereum RPC, ffmpeg, and Docker-provided local services.
- Pointed local test setup at the existing `make dev-deps` shortcut.
- Checked off the matching Priority 1 TODO item.

## Validation

- `make -n dev-deps`
- `git diff --check`